### PR TITLE
qga: fix some errors for guest_get_network_stats

### DIFF
--- a/qga/commands-win32.c
+++ b/qga/commands-win32.c
@@ -1173,20 +1173,26 @@ static int guest_get_network_stats(const char *name,
                        GuestNetworkInterfaceStat *stats)
 {
     DWORD if_index = 0;
-    MIB_IFROW a_mid_ifrow;
-    memset(&a_mid_ifrow, 0, sizeof(a_mid_ifrow));
+    OSVERSIONINFO os_ver;
+
     if_index = get_interface_index(name);
-    a_mid_ifrow.dwIndex = if_index;
-    if (NO_ERROR == GetIfEntry(&a_mid_ifrow)) {
-        stats->rx_bytes = a_mid_ifrow.dwInOctets;
-        stats->rx_packets = a_mid_ifrow.dwInUcastPkts;
-        stats->rx_errs = a_mid_ifrow.dwInErrors;
-        stats->rx_dropped = a_mid_ifrow.dwInDiscards;
-        stats->tx_bytes = a_mid_ifrow.dwOutOctets;
-        stats->tx_packets = a_mid_ifrow.dwOutUcastPkts;
-        stats->tx_errs = a_mid_ifrow.dwOutErrors;
-        stats->tx_dropped = a_mid_ifrow.dwOutDiscards;
-        return 0;
+    os_ver.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
+    GetVersionEx(&os_ver);
+    if (os_ver.dwMajorVersion >= 6) {
+        MIB_IF_ROW2 a_mid_ifrow;
+        memset(&a_mid_ifrow, 0, sizeof(a_mid_ifrow));
+        a_mid_ifrow.InterfaceIndex = if_index;
+        if (NO_ERROR == GetIfEntry2(&a_mid_ifrow)) {
+            stats->rx_bytes = a_mid_ifrow.InOctets;
+            stats->rx_packets = a_mid_ifrow.InUcastPkts;
+            stats->rx_errs = a_mid_ifrow.InErrors;
+            stats->rx_dropped = a_mid_ifrow.InDiscards;
+            stats->tx_bytes = a_mid_ifrow.OutOctets;
+            stats->tx_packets = a_mid_ifrow.OutUcastPkts;
+            stats->tx_errs = a_mid_ifrow.OutErrors;
+            stats->tx_dropped = a_mid_ifrow.OutDiscards;
+            return 0;
+        }
     }
     return -1;
 }


### PR DESCRIPTION
fix some erros:
1.if building qga on Windows Vista/2008 and newer,
it cann't find the link to GetIfEntry2 in windows xp.
2. check valid of if_index.

Signed-off-by: ZhiPeng Lu <lu.zhipeng@zte.com.cn>